### PR TITLE
iter21: add tls support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 bin
 nopush
 data
+keys
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHORTENER_NAME=shortener
 MULTICHECKER_NAME=multichecker
 MOCKS_SOURCE=internal/repository/repository.go
 MOCKS_DEST=internal/mocks/mock_repository.go
+KEYS_DIR=./keys
 
 .PHONY: tidy build run run-debug check-code test bench mock
 
@@ -19,6 +20,11 @@ build-multichecker: tidy
 
 run: build mock
 	@GIN_MODE=release ./bin/${SHORTENER_NAME} ${ARGS}
+
+run-tls: build mock
+	@mkdir -p ${KEYS_DIR}
+	mkcert -cert-file ${KEYS_DIR}/cert.crt -key-file ${KEYS_DIR}/key.pem localhost 127.0.0.1 ::1
+	@GIN_MODE=release ./bin/${SHORTENER_NAME} -s ${ARGS}
 
 run-debug: build up
 	@GIN_MODE=debug ./bin/${SHORTENER_NAME} ${ARGS}
@@ -36,8 +42,8 @@ mock: tidy
 	mockgen -source=${MOCKS_SOURCE} -destination=${MOCKS_DEST} -package=mocks
 
 coverage:
-	go test -covermode=count -coverprofile=coverage.out ./...
-	grep -vE "mocks|repository/database|repository/inmemory" coverage.out > coverage.cleaned.out
+	@go test -covermode=count -coverprofile=coverage.out ./... 0
+	grep -vE "mocks|database|inmemory|cmd" coverage.out > coverage.cleaned.out
 	go tool cover -func=coverage.cleaned.out
 
 up:

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -82,9 +82,21 @@ func main() {
 		"router has been created. web server is ready to start",
 	)
 
-	if err := r.Run(*cfg.ListenAddr); err != nil {
-		logger.Fatal("error starting web server", zap.Error(err))
+	if *cfg.ShouldUseTLS {
+		logger.Info("starting web server with tls config", zap.Any("config", *cfg.TLSConfig))
+		if err := r.RunTLS(
+			*cfg.ListenAddr,
+			cfg.TLSConfig.CrtFilePath,
+			cfg.TLSConfig.KeyFilePath,
+		); err != nil {
+			logger.Fatal("error starting tls web server", zap.Error(err))
+		}
+	} else {
+		if err := r.Run(*cfg.ListenAddr); err != nil {
+			logger.Fatal("error starting simple web server", zap.Error(err))
+		}
 	}
+
 }
 
 func printStartupInfo(l *zap.Logger) {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -2,3 +2,6 @@ defaults:
   listen_addr: ":8080"
   base_url: "http://localhost:8080"
   file_storage_path: ./output.out
+tls:
+  crt_file: keys/cert.crt
+  key_file: keys/key.pem


### PR DESCRIPTION
1. Добавлена возможность включения HTTPS в веб-сервере;
2. Поддержка флага -s и переменной окружения ENABLE_HTTPS