### PR TITLE
iter24: add internal stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       PGDATA: /data/postgres
+    restart: always
     volumes:
        - ./data/postgres:/data/postgres
     ports:

--- a/internal/dto/dto.go
+++ b/internal/dto/dto.go
@@ -29,3 +29,10 @@ type ShortenURLsByUserID struct {
 	ShortURL    string `json:"short_url"`
 	OriginalURL string `json:"original_url"`
 }
+
+// InternalStatsResp represents the response structure containing statistics about
+// the number of shortened URLs and registered users in the system.
+type InternalStatsResp struct {
+	URLs  int `json:"urls"`
+	Users int `json:"user"`
+}

--- a/internal/handler/internal_stats.go
+++ b/internal/handler/internal_stats.go
@@ -10,9 +10,9 @@ import (
 // It calls the Service's GetInternalStats method and returns the result as a JSON response.
 // On success, it responds with HTTP 200 and the statistics data.
 // On failure, it responds with HTTP 500 and an error message.
-func (h HandlerService) InternalStats(c *gin.Context) {
+func (s HandlerService) InternalStats(c *gin.Context) {
 
-	resp, err := h.Service.GetInternalStats(c.Request.Context())
+	resp, err := s.Service.GetInternalStats(c.Request.Context())
 
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/internal/handler/internal_stats.go
+++ b/internal/handler/internal_stats.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// InternalStats handles the request to retrieve internal statistics of the service.
+// It calls the Service's GetInternalStats method and returns the result as a JSON response.
+// On success, it responds with HTTP 200 and the statistics data.
+// On failure, it responds with HTTP 500 and an error message.
+func (h HandlerService) InternalStats(c *gin.Context) {
+
+	resp, err := h.Service.GetInternalStats(c.Request.Context())
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": "internal server error",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/middleware/check_ip.go
+++ b/internal/middleware/check_ip.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mp1947/ya-url-shortener/config"
+	"go.uber.org/zap"
+)
+
+// WithAuthorizedIP is a middleware that restricts access to requests coming from authorized IP addresses.
+// It checks the "X-Real-IP" header of the incoming request and verifies if the IP is within the trusted subnet
+// specified in the configuration. If the IP is authorized, the request proceeds to the next handler.
+// Otherwise, the middleware logs the unauthorized access attempt and responds with HTTP 401 Unauthorized.
+//
+// Parameters:
+//
+//	l      - zap.Logger for logging unauthorized access attempts.
+//	cfg    - config.Config containing the trusted subnet information.
+//	handler - gin.HandlerFunc to be executed if the IP is authorized.
+//
+// Returns:
+//
+//	gin.HandlerFunc - a middleware function for Gin that enforces IP-based authorization.
+func WithAuthorizedIP(
+	l *zap.Logger,
+	cfg config.Config,
+	handler gin.HandlerFunc,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		headerData := c.GetHeader("X-Real-IP")
+
+		ipAddr := net.ParseIP(headerData)
+
+		if ipAddr != nil && cfg.TrustedSubnet.Contains(ipAddr) {
+			handler(c)
+			return
+		}
+
+		l.Info("received unauthorized request from ip", zap.String("ip", headerData))
+
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			"message": "not authorized to access",
+		})
+	}
+}

--- a/internal/mocks/mock_repository.go
+++ b/internal/mocks/mock_repository.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	config "github.com/mp1947/ya-url-shortener/config"
+	dto "github.com/mp1947/ya-url-shortener/internal/dto"
 	model "github.com/mp1947/ya-url-shortener/internal/model"
 	gomock "go.uber.org/mock/gomock"
 	zap "go.uber.org/zap"
@@ -71,6 +72,21 @@ func (m *MockRepository) Get(ctx context.Context, shortURL string) (model.URL, e
 func (mr *MockRepositoryMockRecorder) Get(ctx, shortURL any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRepository)(nil).Get), ctx, shortURL)
+}
+
+// GetInternalStats mocks base method.
+func (m *MockRepository) GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInternalStats", ctx)
+	ret0, _ := ret[0].(*dto.InternalStatsResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInternalStats indicates an expected call of GetInternalStats.
+func (mr *MockRepositoryMockRecorder) GetInternalStats(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInternalStats", reflect.TypeOf((*MockRepository)(nil).GetInternalStats), ctx)
 }
 
 // GetType mocks base method.

--- a/internal/repository/database/queries.go
+++ b/internal/repository/database/queries.go
@@ -8,4 +8,5 @@ const (
 	getOriginalURLByShortIDQuery = `SELECT original_url, is_deleted FROM urls where short_url = @shortURL`
 	getURLsByUserID              = `SELECT original_url, short_url FROM urls where user_uuid = @userID`
 	deleteURLQuery               = `UPDATE urls SET is_deleted = true WHERE short_url = @shortURL AND user_uuid = @userID`
+	getInternalStatsQuery        = `SELECT count(*), count(distinct user_uuid) from urls`
 )

--- a/internal/repository/database/stats.go
+++ b/internal/repository/database/stats.go
@@ -1,0 +1,25 @@
+package database
+
+import (
+	"context"
+
+	"github.com/mp1947/ya-url-shortener/internal/dto"
+)
+
+// GetInternalStats retrieves internal statistics from the database, including the total number of URLs and users.
+// It executes a query to fetch these statistics and returns them as a dto.InternalStatsResp object.
+// If an error occurs during the query or scanning process, it returns the error.
+func (d *Database) GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error) {
+
+	data := d.conn.QueryRow(ctx, getInternalStatsQuery)
+
+	result := dto.InternalStatsResp{}
+
+	err := data.Scan(&result.URLs, &result.Users)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/internal/repository/inmemory/stats.go
+++ b/internal/repository/inmemory/stats.go
@@ -10,6 +10,6 @@ import (
 // It returns a pointer to dto.InternalStatsResp containing the statistics data,
 // or an error if the operation fails.
 // The context parameter allows for request cancellation and timeout control.
-func (m *Memory) GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error) {
+func (s *Memory) GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error) {
 	return nil, nil
 }

--- a/internal/repository/inmemory/stats.go
+++ b/internal/repository/inmemory/stats.go
@@ -1,0 +1,15 @@
+package inmemory
+
+import (
+	"context"
+
+	"github.com/mp1947/ya-url-shortener/internal/dto"
+)
+
+// GetInternalStats retrieves internal statistics from the in-memory repository.
+// It returns a pointer to dto.InternalStatsResp containing the statistics data,
+// or an error if the operation fails.
+// The context parameter allows for request cancellation and timeout control.
+func (m *Memory) GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error) {
+	return nil, nil
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/mp1947/ya-url-shortener/config"
+	"github.com/mp1947/ya-url-shortener/internal/dto"
 	shrterr "github.com/mp1947/ya-url-shortener/internal/errors"
 	"github.com/mp1947/ya-url-shortener/internal/model"
 	"github.com/mp1947/ya-url-shortener/internal/repository/database"
@@ -26,6 +27,7 @@ type Repository interface {
 	Get(ctx context.Context, shortURL string) (model.URL, error)
 	GetURLsByUserID(ctx context.Context, userID string) ([]model.UserURL, error)
 	GetType() string
+	GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error)
 }
 
 // CreateRepository initializes and returns a storage repository based on the provided configuration.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -50,6 +50,8 @@ func CreateRouter(
 	api.GET("/user/urls", h.GetUserURLs)
 	api.DELETE("/user/urls", h.DeleteUserURLs)
 
+	api.GET("/internal/stats", im.WithAuthorizedIP(l, c, h.InternalStats))
+
 	pprof.Register(r, "debug/pprof")
 
 	return r

--- a/internal/service/internal_stats.go
+++ b/internal/service/internal_stats.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+
+	"github.com/mp1947/ya-url-shortener/internal/dto"
+	"go.uber.org/zap"
+)
+
+// GetInternalStats retrieves internal statistics from the storage layer.
+// It returns a dto.InternalStatsResp containing the statistics, or an error if the operation fails.
+// The method logs any errors encountered during the retrieval process.
+//
+// Parameters:
+//   - ctx: context.Context for request-scoped values and cancellation.
+//
+// Returns:
+//   - *dto.InternalStatsResp: Pointer to the response containing internal statistics.
+//   - error: Error encountered during retrieval, if any.
+func (s *ShortenService) GetInternalStats(
+	ctx context.Context,
+) (*dto.InternalStatsResp, error) {
+
+	resp, err := s.Storage.GetInternalStats(ctx)
+
+	if err != nil {
+		s.Logger.Error("received error from storage", zap.Error(err))
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -34,6 +34,7 @@ type Service interface {
 		ctx context.Context,
 		userID string,
 	) ([]dto.ShortenURLsByUserID, error)
+	GetInternalStats(ctx context.Context) (*dto.InternalStatsResp, error)
 }
 
 // ShortenService provides methods for URL shortening operations.


### PR DESCRIPTION
Добавлен в сервер новый эндпоинт GET /api/internal/stats, возвращающий в ответ объект:
```
{
  "urls": <int>, // количество сокращённых URL в сервисе
  "users": <int> // количество пользователей в сервисе
} 
```